### PR TITLE
[datalogger-plotter-with-pyqtgraph.py,plot_method.py] add function for normal

### DIFF
--- a/datalogger-plotter-with-pyqtgraph.py
+++ b/datalogger-plotter-with-pyqtgraph.py
@@ -210,8 +210,8 @@ class DataloggerLogParser:
                         else: # rotation
                             cur_item.setYRange(math.radians(-10), math.radians(+10)) # compensation limit
                     else:
-                        cur_item.plot(times, data_dict[args[0]][:, index],
-                                      pen=pyqtgraph.mkPen(color_list[i], width=len(args_list)-i), name=args[0])
+                        getattr(plot_method.PlotMethod, func)(cur_item, times, data_dict, args, indices_list, arg_indices, cur_col, key, i)
+
             # increase current row
             cur_row = cur_row + 1
 

--- a/plot_method.py
+++ b/plot_method.py
@@ -65,3 +65,6 @@ class PlotMethod(object):
     def plot_rh_q_st_q(plot_item, times, data_dict, args, indices_list, arg_indices, cur_col, key, i):
         plot_item.plot(times, [math.degrees(x) for x in (data_dict[args[1]][:, indices_list[arg_indices[1]][cur_col]] - data_dict[args[0]][:, indices_list[arg_indices[0]][cur_col]])],
                        pen=pyqtgraph.mkPen('r', width=2), name=args[1]+" - rh_q")
+    @staticmethod
+    def normal(plot_item, times, data_dict, args, indices_list, arg_indices, cur_col, key, i):
+        plot_item.plot(times, data_dict[args[0]][:, indices_list[arg_indices[0]][cur_col]], pen=pyqtgraph.mkPen(PlotMethod.color_list[i], width=2, name=args[0]))


### PR DESCRIPTION
plot.yaml (ex. test.yaml)で,funcの表記がない場合、func='normal'が自動で付与されますが、
その場合の関数`normal`を追加しました。
