### PR TITLE
Revert "Merge pull request #6 from rkoyama1623/add-normal-func"

### DIFF
--- a/plot_method.py
+++ b/plot_method.py
@@ -67,4 +67,4 @@ class PlotMethod(object):
                        pen=pyqtgraph.mkPen('r', width=2), name=args[1]+" - rh_q")
     @staticmethod
     def normal(plot_item, times, data_dict, args, indices_list, arg_indices, cur_col, key, i):
-        plot_item.plot(times, data_dict[args[0]][:, indices_list[arg_indices[0]][cur_col]], pen=pyqtgraph.mkPen(PlotMethod.color_list[i], width=2, name=args[0]))
+        plot_item.plot(times, data_dict[args[0]][:, indices_list[arg_indices[0]][cur_col]], pen=pyqtgraph.mkPen(PlotMethod.color_list[i], width=2), name=key)


### PR DESCRIPTION
https://github.com/kindsenior/log-plotter/pull/6 の中で、
`plot_method.py`の中で、凡例の名前の与え方が間違っていました。

``` diff
def normal(plot_item, times, data_dict, args, indices_list, arg_indices, cur_col, key, i):
-  plot_item.plot(times, data_dict[args[0]][:, indices_list[arg_indices[0]][cur_col]], pen=pyqtgraph.mkPen(PlotMethod.color_list[i], width=2, name=args[0]))
+  plot_item.plot(times, data_dict[args[0]][:, indices_list[arg_indices[0]][cur_col]], pen=pyqtgraph.mkPen(PlotMethod.color_list[i], width=2, name=key))
```

mergeされてしまったようなので、revretしてPRします。
