### PR TITLE
add downsampling option

### DIFF
--- a/config/robot/hrp2jsknt/test-layout.yaml
+++ b/config/robot/hrp2jsknt/test-layout.yaml
@@ -50,12 +50,14 @@
     - { key: imu_gsensor, id: [1], label: y }
     - { key: imu_gsensor, id: [2], label: z }
   newline: False
+  downsampling: {ds: 100, auto: False, mode: peak}
 
 - title: imu_gyrometer
   legends:
     - { key: imu_gyrometer, id: [0], label: x }
     - { key: imu_gyrometer, id: [1], label: y }
     - { key: imu_gyrometer, id: [2], label: z }
+  downsampling: {ds: 100, auto: False, mode: peak}
 
 - title: comp
   legends:

--- a/datalogger-plotter-with-pyqtgraph.py
+++ b/datalogger-plotter-with-pyqtgraph.py
@@ -128,6 +128,10 @@ class DataloggerLogParser:
                 self.legend_list[graph_row].append([])
                 plot_item.setTitle(group['title']+" "+str(j))
                 plot_item.showGrid(x=True, y=True)
+                if group.has_key('downsampling'):
+                    plot_item.setDownsampling(ds = group['downsampling'].get('ds', 100),
+                                              auto=group['downsampling'].get('auto', False),
+                                              mode=group['downsampling'].get('mode', 'peak'))
 
                 # add legend info to this graph
                 for k in range(len(group['legends'])):


### PR DESCRIPTION
一つしかグラフを描画しなくても、１pxに何度もグラフを描画して重くなり、ウィンドウが固まるプロットがあるので、
pyqtgraphのデフォルト機能でguiからも設定できるdownsamplingの設定をyamlから設定できるようにしました。

1. yamlの場合
以下のように設定します。
ds, auto, modeの意味は、
http://www.pyqtgraph.org/documentation/graphicsItems/plotdataitem.html
の中の
Optimization keyword arguments
で説明されています。
ds=100で、プロット数を1/100にするようです。

```yaml
- title: imu_gsensor
  legends:
    - { key: imu_gsensor, id: [0], label: x }
    - { key: imu_gsensor, id: [1], label: y }
    - { key: imu_gsensor, id: [2], label: z }
  downsampling: {ds: 100, auto: False, mode: peak}
```
2. guiの場合
グラフを右クリック→"Plot Options"→"Downsample"


