### PR TITLE
[datalogger_plotter_with_pyqtgraph.py] Convert servoState faster

### DIFF
--- a/src/log_plotter/datalogger_plotter_with_pyqtgraph.py
+++ b/src/log_plotter/datalogger_plotter_with_pyqtgraph.py
@@ -6,7 +6,6 @@ import functools
 import math
 import multiprocessing
 import numpy
-import struct
 import sys
 import time
 import yaml
@@ -133,11 +132,8 @@ class DataloggerLogParser:
             self.dataListDict[topic][:, 0] = [x - min_time for x in raw_time]
         # fix servoState
         if 'RobotHardware0_servoState' in topic_list:
-            def servoStatesConverter(x):
-                return struct.unpack('f', struct.pack('i', int(x)))[0]
-            vf = numpy.vectorize(servoStatesConverter)
             ss_tmp = self.dataListDict['RobotHardware0_servoState'][:, 1:]
-            self.dataListDict['RobotHardware0_servoState'][:, 1:] = vf(ss_tmp)
+            self.dataListDict['RobotHardware0_servoState'][:, 1:] = numpy.fromstring(ss_tmp.astype('i').tostring(), dtype='f').reshape(ss_tmp.shape)
 
     @my_time
     def setLayout(self):


### PR DESCRIPTION
Refer to #1 
numpyのfromstringとtostringを用いることで型変換を速くしました
以下参考データ
before this PR：
```
start : readData
  readData : 4.421 [s]
```
after this PR：
```
start : readData
  readData : 2.364 [s]
```