### PR TITLE
Fix hide exc column cb

### DIFF
--- a/src/log_plotter/datalogger_plotter_with_pyqtgraph.py
+++ b/src/log_plotter/datalogger_plotter_with_pyqtgraph.py
@@ -295,21 +295,15 @@ class DataloggerLogParser:
                 for i in del_list:
                     self.view.ci.removeItem(i)
             def hideExcRowCB(item):
-                del_list = self.view.ci.items.keys()
                 r, _c = self.view.ci.items[item][0]
                 not_del_list=[self.view.ci.rows[r][c] for c in self.view.ci.rows[r].keys()]
-                for i in del_list:
-                    if i in not_del_list:
-                        del_list.remove(i)
+                del_list = [x for x in self.view.ci.items.keys() if x not in not_del_list]
                 for i in del_list:
                     self.view.ci.removeItem(i)
             def hideExcColumnCB(item):
-                del_list = self.view.ci.items.keys()
                 _r, c = self.view.ci.items[item][0]
-                not_del_list=[self.view.ci.rows[r][c] for r in range(len(a.view.ci.rows))]
-                for i in del_list:
-                    if i in not_del_list:
-                        del_list.remove(i)
+                not_del_list=[self.view.ci.rows[r][c] for r in range(len(self.view.ci.rows))]
+                del_list = [x for x in self.view.ci.items.keys() if x not in not_del_list]
                 for i in del_list:
                     self.view.ci.removeItem(i)
             def restoreCB():

--- a/src/log_plotter/datalogger_plotter_with_pyqtgraph.py
+++ b/src/log_plotter/datalogger_plotter_with_pyqtgraph.py
@@ -272,7 +272,7 @@ class DataloggerLogParser:
             qa4 = vb.menu.addAction('restore plots')
             qa5 = hm.addAction('hide except this plot')
             qa6 = hm.addAction('hide except this row')
-            qa7 = hm.addAction('hide except this colmn')
+            qa7 = hm.addAction('hide except this column')
             def hideCB(item):
                 self.view.ci.removeItem(item)
             def hideRowCB(item):


### PR DESCRIPTION
hide except this row / columnに関する修正です．
(1): hideExcColumnCB内 a.view.ci.rows となっている部分をselfに修正しました．
(2): del_listからnon_del_listをremoveする記述を内包表現にしました．
(3): タイポを修正しました．

特に(2)について一応書いておくと，あるリストに関してループを回しつつそのリストに変更を加えるというのは挙動として怪しいです．
以下例
```python
In [1]: a = [1,2,3,4,5,6,7,8,9]

In [2]: b = [2,6,4,3]

In [3]: for i in a:
   ...:     print i
   ...:     if i in b:
   ...:         a.remove(i)
   ...:         
1
2
4
6
8
9

In [4]: print a
[1, 3, 5, 7, 8, 9]
```
ループがすべてのaを回っていない

ちなみに，hide except this columnが異様に遅い気がします