### PR TITLE
[datalogger_plotter_with_pyqtgraph.py] Fix 'index out of range' bug of hideExc

### DIFF
--- a/src/log_plotter/datalogger_plotter_with_pyqtgraph.py
+++ b/src/log_plotter/datalogger_plotter_with_pyqtgraph.py
@@ -296,14 +296,12 @@ class DataloggerLogParser:
                     self.view.ci.removeItem(i)
             def hideExcRowCB(item):
                 r, _c = self.view.ci.items[item][0]
-                not_del_list=[self.view.ci.rows[r][c] for c in self.view.ci.rows[r].keys()]
-                del_list = [x for x in self.view.ci.items.keys() if x not in not_del_list]
+                del_list = [x for x in self.view.ci.items.keys() if self.view.ci.items[x][0][0] != r]
                 for i in del_list:
                     self.view.ci.removeItem(i)
             def hideExcColumnCB(item):
                 _r, c = self.view.ci.items[item][0]
-                not_del_list=[self.view.ci.rows[r][c] for r in range(len(self.view.ci.rows))]
-                del_list = [x for x in self.view.ci.items.keys() if x not in not_del_list]
+                del_list = [x for x in self.view.ci.items.keys() if self.view.ci.items[x][0][1] != c]
                 for i in del_list:
                     self.view.ci.removeItem(i)
             def restoreCB():


### PR DESCRIPTION
![screenshot from 2016-12-15 03 10 21](https://cloud.githubusercontent.com/assets/5689714/21194917/12752862-c275-11e6-827d-2ab9fecb65e4.png)
例えば図の80V 3でhide except this columnを実行するとnot_del_listを作る時に空白のスペースにアクセスしようとしてエラーが出ていたのを修正いたしました．