### PR TITLE
[src/log_plotter/datalogger_plotter_with_pyqtgraph.py] use absolute path when search RobotHardware lot

### DIFF
--- a/src/log_plotter/datalogger_plotter_with_pyqtgraph.py
+++ b/src/log_plotter/datalogger_plotter_with_pyqtgraph.py
@@ -62,7 +62,7 @@ def findFile(pattern, path):
 
 # replace RobotHardware0 to each simulation one
 def replaceRH(fname_list):
-    log_dir = os.path.dirname(fname_list[0])
+    log_dir = os.path.dirname(os.path.abspath(fname_list[0]))
     base_name = os.path.splitext(os.path.basename(fname_list[0]))[0]
     # choreonoid
     if findFile(base_name + '.RobotHardware_choreonoid0_*', log_dir):


### PR DESCRIPTION
#26 をコマンドラインから使うとき，ログファイルのパスが相対パスで与えられる場合があるので，絶対パスに直してから読み込むようにしました．