### PR TITLE
Matplotlib like

### DIFF
--- a/src/log_plotter/datalogger_plotter_with_pyqtgraph.py
+++ b/src/log_plotter/datalogger_plotter_with_pyqtgraph.py
@@ -153,13 +153,12 @@ class DataloggerLogParser:
                 # add graph
                 plot_item = self.view.addPlot(viewBox = pyqtgraph.ViewBox(border = pyqtgraph.mkPen(color='k', width=2)))
                 self.legend_list[graph_row].append([])
-                plot_item.setTitle(group['title']+" "+str(j))
-                plot_item.showGrid(x=True, y=True)
+                plot_item.setTitle(group['title']+" "+str(j), color ='000000')
+                plot_item.showGrid(x=True, y=True, alpha=1)
                 if group.has_key('downsampling'):
                     plot_item.setDownsampling(ds = group['downsampling'].get('ds', 100),
                                               auto=group['downsampling'].get('auto', False),
                                               mode=group['downsampling'].get('mode', 'peak'))
-
                 # add legend info to this graph
                 for k in range(len(group['legends'])):
                     legend_info = GraphLegendInfo(self.layout_list, self.plot_dict, i, j, k)

--- a/src/log_plotter/datalogger_plotter_with_pyqtgraph.py
+++ b/src/log_plotter/datalogger_plotter_with_pyqtgraph.py
@@ -16,6 +16,7 @@ import signal
 import log_plotter.plot_method as plot_method
 from log_plotter.graph_legend import GraphLegendInfo, expand_str_to_list
 import log_plotter.yaml_selector as yaml_selector
+import log_plotter.pyqtgraph_LegendItem_patch
 
 try:
     import pyqtgraph

--- a/src/log_plotter/datalogger_plotter_with_pyqtgraph.py
+++ b/src/log_plotter/datalogger_plotter_with_pyqtgraph.py
@@ -151,7 +151,7 @@ class DataloggerLogParser:
             group_len = max(len(leg['id']) for leg in group['legends'])
             for j in range(group_len):
                 # add graph
-                plot_item = self.view.addPlot()
+                plot_item = self.view.addPlot(viewBox = pyqtgraph.ViewBox(border = pyqtgraph.mkPen(color='k', width=2)))
                 self.legend_list[graph_row].append([])
                 plot_item.setTitle(group['title']+" "+str(j))
                 plot_item.showGrid(x=True, y=True)

--- a/src/log_plotter/datalogger_plotter_with_pyqtgraph.py
+++ b/src/log_plotter/datalogger_plotter_with_pyqtgraph.py
@@ -257,6 +257,13 @@ class DataloggerLogParser:
                     if i != 0:
                         p.setYLink(target_item)
 
+        # design
+        for i, p in enumerate(self.view.ci.items.keys()):
+            ax = p.getAxis('bottom')
+            ax.setPen(pyqtgraph.mkPen('k', width=1, style=pyqtgraph.QtCore.Qt.DashLine))
+            ax = p.getAxis('left')
+            ax.setPen(pyqtgraph.mkPen('k', width=1, style=pyqtgraph.QtCore.Qt.DashLine))
+
     @my_time
     def customMenu(self):
         '''


### PR DESCRIPTION
#43 の

> 1. フォント，フォントサイズを指定する
> 1. グラフのサイズを指定できるようにする
> 1. 軸の色を灰色から黒にし，補助線を点線にする
> 1. グラフの系列(?)の背景を薄灰色から白塗りつぶしにする
> 1. グラフの色を見やすくする

のうち，３と４に対応しました．

![before](https://cloud.githubusercontent.com/assets/11606776/21354842/f11e2030-c70e-11e6-8671-7356be6bbca7.png)
![after](https://cloud.githubusercontent.com/assets/11606776/21354850/f4bb6cfc-c70e-11e6-9e48-5b631504273f.png)

