### PR TITLE
[datalogger_plotter_with_pyqtgraph.py] Reduce grid line width

### DIFF
--- a/src/log_plotter/datalogger_plotter_with_pyqtgraph.py
+++ b/src/log_plotter/datalogger_plotter_with_pyqtgraph.py
@@ -259,9 +259,9 @@ class DataloggerLogParser:
         # design
         for i, p in enumerate(self.view.ci.items.keys()):
             ax = p.getAxis('bottom')
-            ax.setPen(pyqtgraph.mkPen('k', width=1, style=pyqtgraph.QtCore.Qt.DashLine))
+            ax.setPen(pyqtgraph.mkPen('k', width=0.5, style=pyqtgraph.QtCore.Qt.DashLine))
             ax = p.getAxis('left')
-            ax.setPen(pyqtgraph.mkPen('k', width=1, style=pyqtgraph.QtCore.Qt.DashLine))
+            ax.setPen(pyqtgraph.mkPen('k', width=0.5, style=pyqtgraph.QtCore.Qt.DashLine))
 
     @my_time
     def customMenu(self):


### PR DESCRIPTION
width=1だとグリッド線がうるさかったので，0.5に変更しました．
![hoge](https://cloud.githubusercontent.com/assets/5689714/21356038/9d2d93de-c713-11e6-91a5-82db3b4568e3.png)

1の場合: #45 下段
