### PR TITLE
[src/log_plotter/datalogger_plotter_with_pyqtgraph.py] Modify unit style () -> []

### DIFF
--- a/src/log_plotter/datalogger_plotter_with_pyqtgraph.py
+++ b/src/log_plotter/datalogger_plotter_with_pyqtgraph.py
@@ -218,7 +218,9 @@ class DataloggerLogParser:
                 tmp_units = "deg/s"
             elif ("watt" in title):
                 tmp_units = "W"
-            cur_item.setLabel("left", text="", units=tmp_units)
+            # cur_item.setLabel("left", text="", units=tmp_units)
+            if tmp_units:
+                cur_item.setLabel("left", text="["+tmp_units+"]")
             # we need this to suppress si-prefix until https://github.com/pyqtgraph/pyqtgraph/pull/293 is merged
             for ax in cur_item.axes.values():
                 ax['item'].enableAutoSIPrefix(enable=False)


### PR DESCRIPTION
単位の形式を()から[]に変更しました.
sourceを見ると
pyqtgraphの単位の形式に乗っ取ると()が勝手につくようです.