### PR TITLE
[src/log_plotter/pyqtgraph_LegendItem_patch.py] enable to change space in LegendItem

### DIFF
--- a/src/log_plotter/pyqtgraph_LegendItem_patch.py
+++ b/src/log_plotter/pyqtgraph_LegendItem_patch.py
@@ -54,16 +54,26 @@ class HorizenLegend(GraphicsWidget):
 def LegendItem_updateSize(self):
     if self.size is not None:
         return
-    height = 0
-    width = 0
+    margins = self.layout.getContentsMargins()
+    height = margins[1] + margins[3]
+    width = margins[0] + margins[2] + self.layout.horizontalSpacing()
     #print("-------")
     for sample, label in self.items:
-        height += max(sample.height(), label.height()) + 3
+        height += max(sample.height(), label.height()) + self.layout.verticalSpacing()
         width = max(width, sample.width()+label.width())
         #print(width, height)
+    height -= self.layout.verticalSpacing()
     #print width, height
     # self.setGeometry(0, 0, width+25, height)
-    self.setGeometry(0, 0, width+35, height)
+    self.setGeometry(0, 0, width, height)
+
+# set default value in LegendItem
+LegendItem_init_orig = pyqtgraph.graphicsItems.LegendItem.LegendItem.__init__
+def LegendItem_init(self, *args, **kwargs):
+    LegendItem_init_orig(self, *args, **kwargs)
+    self.layout.setContentsMargins(9.,0.,9.,0.)
+    self.layout.setVerticalSpacing(-5.)
+    self.layout.setHorizontalSpacing(25)
 
 # justify left for legend label
 from pyqtgraph.graphicsItems.LabelItem import LabelItem
@@ -79,7 +89,7 @@ def LegendItem_addItem(self, item, name):
     self.layout.addItem(label, row, 1)
     self.updateSize()
 
-
+pyqtgraph.graphicsItems.LegendItem.LegendItem.__init__ = LegendItem_init
 pyqtgraph.graphicsItems.LegendItem.LegendItem.paint = white_foreground_legend_item_paint
 pyqtgraph.graphicsItems.LegendItem.LegendItem.updateSize = LegendItem_updateSize
 pyqtgraph.graphicsItems.LegendItem.LegendItem.addItem = LegendItem_addItem


### PR DESCRIPTION
デフォルトのグラフの凡例のスペースを詰めたのと，後からスペースを変更できるようにしました．

![legenditem](https://cloud.githubusercontent.com/assets/11606776/23339147/1c18b806-fc5f-11e6-8cbe-773bbc2e6318.png)

変更の仕方としては，
```python
legend = a.view.ci.rows[0][0].legend # LegendItemを取得
legend.layout.setVerticalSpacing(0) # 凡例どうしの垂直スペースを0にする(負の数も可能)
legend.layout.setHorizontalSpacing(0) # 凡例どうしの水平スペースを0にする(負の数も可能)
left = bottom = 0
left = right = 9
legend.layout.setContentsMargins(left,top,right,bottom) # 凡例の周囲との間のマージンを設定
legend.updateSize() # 設定の変更を反映させる
```