### PR TITLE
Fix 87 again

### DIFF
--- a/src/log_plotter/datalogger_plotter_with_pyqtgraph.py
+++ b/src/log_plotter/datalogger_plotter_with_pyqtgraph.py
@@ -210,7 +210,8 @@ class LogPlotter(object):
                         x_range.setdefault('max', ax.range[1])
                         del ax
                     plot_item.setXRange(0 if x_range.get('zero') else x_range['min'],
-                                        x_range['max']-x_range['min'] if x_range.get('zero') else x_range['max'])
+                                        x_range['max']-x_range['min'] if x_range.get('zero') else x_range['max'],
+                                        padding=0)
                 # set yRange
                 y_range = self.legend_list[i][j][0].group_info.get("yRange")
                 if y_range:
@@ -222,7 +223,7 @@ class LogPlotter(object):
                         ax = plot_item.getAxis('left')
                         y_range.setdefault('max', ax.range[1])
                         del ax
-                    plot_item.setYRange(y_range['min'], y_range['max'])
+                    plot_item.setYRange(y_range['min'], y_range['max'], padding=0)
 
         all_items = self.view.ci.items.keys()
         # link X axis and set AutoRange


### PR DESCRIPTION
#93で#87を直したつもりでしたが，条件によって直っていませんでした．
PRの内容は以下です．

1. #87でyRangeのmin/maxの一方を省略可能にした．また，0行0列目のグラフだけyRangeが反映されなかったのを直した．
2. xRange/yRangeの指定をしたとき，minとmaxの外側に少しだけ隙間が空いていたのをpaddingキーワード引数を0にして直した．