### PR TITLE
Support non exist log data

### DIFF
--- a/config/common_plot.yaml
+++ b/config/common_plot.yaml
@@ -8,6 +8,18 @@ st_originActCog:
 st_originRefCog:
   data:
     - { log: st_originRefCog, column: [0-2] }
+abc_originActCog:
+  data:
+    - { log: abc_originActCog, column: [0-2] }
+abc_originRefCog:
+  data:
+    - { log: abc_originRefCog, column: [0-2] }
+abst_originActCog:
+  data:
+    - { log: abst_originActCog, column: [0-2] }
+abst_originRefCog:
+  data:
+    - { log: abst_originRefCog, column: [0-2] }
 ## cog velocity
 st_originActCogVel:
   data:
@@ -15,6 +27,18 @@ st_originActCogVel:
 st_originRefCogVel:
   data:
     - { log: st_originRefCogVel, column: [0-2] }
+abc_originActCogVel:
+  data:
+    - { log: abc_originActCogVel, column: [0-2] }
+abc_originRefCogVel:
+  data:
+    - { log: abc_originRefCogVel, column: [0-2] }
+abst_originActCogVel:
+  data:
+    - { log: abst_originActCogVel, column: [0-2] }
+abst_originRefCogVel:
+  data:
+    - { log: abst_originRefCogVel, column: [0-2] }
 ## zmp
 abc_zmpOut:
   data:
@@ -31,10 +55,34 @@ st_originRefZmp:
 st_originNewZmp:
   data:
     - { log: st_originNewZmp, column: [0-2] }
+abc_originActZmp:
+  data:
+    - { log: abc_originActZmp, column: [0-2] }
+abc_originRefZmp:
+  data:
+    - { log: abc_originRefZmp, column: [0-2] }
+abc_originNewZmp:
+  data:
+    - { log: abc_originNewZmp, column: [0-2] }
+abst_originActZmp:
+  data:
+    - { log: abst_originActZmp, column: [0-2] }
+abst_originRefZmp:
+  data:
+    - { log: abst_originRefZmp, column: [0-2] }
+abst_originNewZmp:
+  data:
+    - { log: abst_originNewZmp, column: [0-2] }
 # root-link relative zmp
 st_zmp:
   data:
     - { log: st_zmp, column: [0-2] }
+abc_zmp:
+  data:
+    - { log: abc_zmp, column: [0-2] }
+abst_zmp:
+  data:
+    - { log: abst_zmp, column: [0-2] }
 ## force
 sh_rfsensorOut:
   data:
@@ -86,6 +134,30 @@ st_ref_rhsensor:
 st_ref_lhsensor:
   data:
     - { log: st_allRefWrench, column: [18-23] }
+abc_ref_rfsensor:
+  data:
+    - { log: abc_allRefWrench, column: [0-5] }
+abc_ref_lfsensor:
+  data:
+    - { log: abc_allRefWrench, column: [6-11] }
+abc_ref_rhsensor:
+  data:
+    - { log: abc_allRefWrench, column: [12-17] }
+abc_ref_lhsensor:
+  data:
+    - { log: abc_allRefWrench, column: [18-23] }
+abst_ref_rfsensor:
+  data:
+    - { log: abst_allRefWrench, column: [0-5] }
+abst_ref_lfsensor:
+  data:
+    - { log: abst_allRefWrench, column: [6-11] }
+abst_ref_rhsensor:
+  data:
+    - { log: abst_allRefWrench, column: [12-17] }
+abst_ref_lhsensor:
+  data:
+    - { log: abst_allRefWrench, column: [18-23] }
 abc_rfsensor:
   data:
     - { log: abc_rfsensor, column: [0-2] }
@@ -109,6 +181,38 @@ st_lhcomp:
   func: plot_comp
   data:
     - { log: st_allEEComp, column: [18-23] }
+abc_rfcomp:
+  func: plot_comp
+  data:
+    - { log: abc_allEEComp, column: [0-5] }
+abc_lfcomp:
+  func: plot_comp
+  data:
+    - { log: abc_allEEComp, column: [6-11] }
+abc_rhcomp:
+  func: plot_comp
+  data:
+    - { log: abc_allEEComp, column: [12-17] }
+abc_lhcomp:
+  func: plot_comp
+  data:
+    - { log: abc_allEEComp, column: [18-23] }
+abst_rfcomp:
+  func: plot_comp
+  data:
+    - { log: abst_allEEComp, column: [0-5] }
+abst_lfcomp:
+  func: plot_comp
+  data:
+    - { log: abst_allEEComp, column: [6-11] }
+abst_rhcomp:
+  func: plot_comp
+  data:
+    - { log: abst_allEEComp, column: [12-17] }
+abst_lhcomp:
+  func: plot_comp
+  data:
+    - { log: abst_allEEComp, column: [18-23] }
 # imu
 imu_gsensor:
   data:
@@ -130,6 +234,22 @@ st_currentBaseRpy:
   func: plot_rad2deg
   data:
     - { log: st_currentBaseRpy, column: [0-2] }
+abc_actBaseRpy:
+  func: plot_rad2deg
+  data:
+    - { log: abc_actBaseRpy, column: [0-2] }
+abc_currentBaseRpy:
+  func: plot_rad2deg
+  data:
+    - { log: abc_currentBaseRpy, column: [0-2] }
+abst_actBaseRpy:
+  func: plot_rad2deg
+  data:
+    - { log: abst_actBaseRpy, column: [0-2] }
+abst_currentBaseRpy:
+  func: plot_rad2deg
+  data:
+    - { log: abst_currentBaseRpy, column: [0-2] }
 kf_rpy:
   func: plot_rad2deg
   data:
@@ -146,6 +266,22 @@ st_actBaseRpyVel:
   func: plot_rad2deg_vel
   data:
     - { log: st_actBaseRpy, column: [0-2] }
+abc_currentBaseRpyVel:
+  func: plot_rad2deg_vel
+  data:
+    - { log: abc_currentBaseRpy, column: [0-2] }
+abc_actBaseRpyVel:
+  func: plot_rad2deg_vel
+  data:
+    - { log: abc_actBaseRpy, column: [0-2] }
+abst_currentBaseRpyVel:
+  func: plot_rad2deg_vel
+  data:
+    - { log: abst_currentBaseRpy, column: [0-2] }
+abst_actBaseRpyVel:
+  func: plot_rad2deg_vel
+  data:
+    - { log: abst_actBaseRpy, column: [0-2] }
 # pos
 abc_basePos:
   data:
@@ -153,6 +289,12 @@ abc_basePos:
 st_currentBasePos:
   data:
     - { log: st_currentBasePos, column: [0-2] }
+abc_currentBasePos:
+  data:
+    - { log: abc_currentBasePos, column: [0-2] }
+abst_currentBasePos:
+  data:
+    - { log: abst_currentBasePos, column: [0-2] }
 # optional data
 abc_contactStates:
   data:
@@ -164,6 +306,12 @@ abc_controlSwingSupportTime:
 st_debugData:
   data:
     - { log: st_debugData, column:[0-3] }
+abc_debugData:
+  data:
+    - { log: abc_debugData, column:[0-3] }
+abst_debugData:
+  data:
+    - { log: abst_debugData, column:[0-3] }
 # COP
 sh_rfcop:
   data:
@@ -180,6 +328,22 @@ st_rfcop:
 st_lfcop:
   data:
     - { log: st_allRefWrench, column: [6-11] }
+  func: plot_COP
+abc_rfcop:
+  data:
+    - { log: abc_allRefWrench, column: [0-5] }
+  func: plot_COP
+abc_lfcop:
+  data:
+    - { log: abc_allRefWrench, column: [6-11] }
+  func: plot_COP
+abst_rfcop:
+  data:
+    - { log: abst_allRefWrench, column: [0-5] }
+  func: plot_COP
+abst_lfcop:
+  data:
+    - { log: abst_allRefWrench, column: [6-11] }
   func: plot_COP
 rmfo_rfcop:
   data:
@@ -204,6 +368,22 @@ st_rhcop:
 st_lhcop:
   data:
     - { log: st_allRefWrench, column: [17-23] }
+  func: plot_COP
+abc_rhcop:
+  data:
+    - { log: abc_allRefWrench, column: [12-17] }
+  func: plot_COP
+abc_lhcop:
+  data:
+    - { log: abc_allRefWrench, column: [17-23] }
+  func: plot_COP
+abst_rhcop:
+  data:
+    - { log: abst_allRefWrench, column: [12-17] }
+  func: plot_COP
+abst_lhcop:
+  data:
+    - { log: abst_allRefWrench, column: [17-23] }
   func: plot_COP
 rmfo_rhcop:
   data:

--- a/config/comp-arm_layout.yaml
+++ b/config/comp-arm_layout.yaml
@@ -3,9 +3,17 @@ main:
     legends:
       - { key: st_rhcomp, id: [2] }
       - { key: st_lhcomp, id: [2] }
+      - { key: abc_rhcomp, id: [2] }
+      - { key: abc_lhcomp, id: [2] }
+      - { key: abst_rhcomp, id: [2] }
+      - { key: abst_lhcomp, id: [2] }
     newline: false
 
   arm moment comp:
     legends:
       - { key: st_rhcomp, id: [3-4] }
       - { key: st_lhcomp, id: [3-4] }
+      - { key: abc_rhcomp, id: [3-4] }
+      - { key: abc_lhcomp, id: [3-4] }
+      - { key: abst_rhcomp, id: [3-4] }
+      - { key: abst_lhcomp, id: [3-4] }

--- a/config/comp-leg_layout.yaml
+++ b/config/comp-leg_layout.yaml
@@ -3,9 +3,17 @@ main:
     legends:
       - { key: st_rfcomp, id: [2] }
       - { key: st_lfcomp, id: [2] }
+      - { key: abc_rfcomp, id: [2] }
+      - { key: abc_lfcomp, id: [2] }
+      - { key: abst_rfcomp, id: [2] }
+      - { key: abst_lfcomp, id: [2] }
     newline: false
 
   leg moment comp:
     legends:
       - { key: st_rfcomp, id: [3-4] }
       - { key: st_lfcomp, id: [3-4] }
+      - { key: abc_rfcomp, id: [3-4] }
+      - { key: abc_lfcomp, id: [3-4] }
+      - { key: abst_rfcomp, id: [3-4] }
+      - { key: abst_lfcomp, id: [3-4] }

--- a/config/cop_layout.yaml
+++ b/config/cop_layout.yaml
@@ -4,6 +4,8 @@ main:
       - { key: sh_rfcop, id: [0-1] }
       - { key: sh_lfcop, id: [0-1] }
       - { key: st_rfcop, id: [0-1] }
+      - { key: abc_rfcop, id: [0-1] }
+      - { key: abst_rfcop, id: [0-1] }
       - { key: rmfo_rfcop, id: [0-1] }
     bottom_label:
     newline: false
@@ -13,6 +15,8 @@ main:
       - { key: sh_rhcop, id: [0-1] }
       - { key: sh_lhcop, id: [0-1] }
       - { key: st_rhcop, id: [0-1] }
+      - { key: abc_rhcop, id: [0-1] }
+      - { key: abst_rhcop, id: [0-1] }
       - { key: rmfo_rhcop, id: [0-1] }
     bottom_label:
 

--- a/config/robot/jaxon/jaxon-joint-real-arm_layout.yaml
+++ b/config/robot/jaxon/jaxon-joint-real-arm_layout.yaml
@@ -20,6 +20,14 @@ main:
       # - { key: abc_q, id: [22],label: abc_wrist-y }
       # - { key: abc_q, id: [23],label: abc_wrist-r }
       # - { key: abc_q, id: [24],label: abc_wrist-p }
+      - { key: abst_q, id: [17],label: abst_collar-y }
+      - { key: abst_q, id: [18],label: abst_shoulder-p }
+      - { key: abst_q, id: [19],label: abst_shoulder-r }
+      - { key: abst_q, id: [20],label: abst_shoulder-y }
+      - { key: abst_q, id: [21],label: abst_elbow-p }
+      - { key: abst_q, id: [22],label: abst_wrist-y }
+      - { key: abst_q, id: [23],label: abst_wrist-r }
+      - { key: abst_q, id: [24],label: abst_wrist-p }
       # - { key: el_q, id: [17],label: el_collar-y }
       # - { key: el_q, id: [18],label: el_shoulder-p }
       # - { key: el_q, id: [19],label: el_shoulder-r }
@@ -65,6 +73,14 @@ main:
       # - { key: abc_q, id: [30], label: abc_wrist-y }
       # - { key: abc_q, id: [31], label: abc_wrist-r }
       # - { key: abc_q, id: [32], label: abc_wrist-p }
+      - { key: abst_q, id: [25],  label: abst_collar-y }
+      - { key: abst_q, id: [26],  label: abst_shoulder-p }
+      - { key: abst_q, id: [27],  label: abst_shoulder-r }
+      - { key: abst_q, id: [28],  label: abst_shoulder-y }
+      - { key: abst_q, id: [29], label: abst_elbow-p }
+      - { key: abst_q, id: [30], label: abst_wrist-y }
+      - { key: abst_q, id: [31], label: abst_wrist-r }
+      - { key: abst_q, id: [32], label: abst_wrist-p }
       # - { key: el_q, id: [25],  label: el_collar-y }
       # - { key: el_q, id: [26],  label: el_shoulder-p }
       # - { key: el_q, id: [27],  label: el_shoulder-r }

--- a/config/robot/jaxon/jaxon-joint-real-leg_layout.yaml
+++ b/config/robot/jaxon/jaxon-joint-real-leg_layout.yaml
@@ -16,6 +16,12 @@ main:
       # - { key: abc_q, id: [3],label: abc_knee-p }
       # - { key: abc_q, id: [4],label: abc_ankle-p}
       # - { key: abc_q, id: [5],label: abc_ankle-r}
+      - { key: abst_q, id: [0],label: abst_hip-y  }
+      - { key: abst_q, id: [1],label: abst_hip-r  }
+      - { key: abst_q, id: [2],label: abst_hip-p  }
+      - { key: abst_q, id: [3],label: abst_knee-p }
+      - { key: abst_q, id: [4],label: abst_ankle-p}
+      - { key: abst_q, id: [5],label: abst_ankle-r}
       # - { key: el_q, id: [0],label: el_hip-y  }
       # - { key: el_q, id: [1],label: el_hip-r  }
       # - { key: el_q, id: [2],label: el_hip-p  }
@@ -51,6 +57,12 @@ main:
       # - { key: abc_q, id: [9],  label: abc_knee-p }
       # - { key: abc_q, id: [10], label: abc_ankle-p}
       # - { key: abc_q, id: [11], label: abc_ankle-r}
+      - { key: abst_q, id: [6],  label: abst_hip-y  }
+      - { key: abst_q, id: [7],  label: abst_hip-r  }
+      - { key: abst_q, id: [8],  label: abst_hip-p  }
+      - { key: abst_q, id: [9],  label: abst_knee-p }
+      - { key: abst_q, id: [10], label: abst_ankle-p}
+      - { key: abst_q, id: [11], label: abst_ankle-r}
       # - { key: el_q, id: [6],  label: el_hip-y  }
       # - { key: el_q, id: [7],  label: el_hip-r  }
       # - { key: el_q, id: [8],  label: el_hip-p  }

--- a/config/robot/jaxon/jaxon-joint-simulator-arm_layout.yaml
+++ b/config/robot/jaxon/jaxon-joint-simulator-arm_layout.yaml
@@ -17,6 +17,14 @@ main:
       # - { key: abc_q, id: [22],label: abc_wrist-y }
       # - { key: abc_q, id: [23],label: abc_wrist-r }
       # - { key: abc_q, id: [24],label: abc_wrist-p }
+      - { key: abst_q, id: [17],label: abst_collar-y }
+      - { key: abst_q, id: [18],label: abst_shoulder-p }
+      - { key: abst_q, id: [19],label: abst_shoulder-r }
+      - { key: abst_q, id: [20],label: abst_shoulder-y }
+      - { key: abst_q, id: [21],label: abst_elbow-p }
+      - { key: abst_q, id: [22],label: abst_wrist-y }
+      - { key: abst_q, id: [23],label: abst_wrist-r }
+      - { key: abst_q, id: [24],label: abst_wrist-p }
       # - { key: el_q, id: [17],label: el_collar-y }
       # - { key: el_q, id: [18],label: el_shoulder-p }
       # - { key: el_q, id: [19],label: el_shoulder-r }
@@ -54,6 +62,14 @@ main:
       # - { key: abc_q, id: [30], label: abc_wrist-y }
       # - { key: abc_q, id: [31], label: abc_wrist-r }
       # - { key: abc_q, id: [32], label: abc_wrist-p }
+      - { key: abst_q, id: [25],  label: abst_collar-y }
+      - { key: abst_q, id: [26],  label: abst_shoulder-p }
+      - { key: abst_q, id: [27],  label: abst_shoulder-r }
+      - { key: abst_q, id: [28],  label: abst_shoulder-y }
+      - { key: abst_q, id: [29], label: abst_elbow-p }
+      - { key: abst_q, id: [30], label: abst_wrist-y }
+      - { key: abst_q, id: [31], label: abst_wrist-r }
+      - { key: abst_q, id: [32], label: abst_wrist-p }
       # - { key: el_q, id: [25],  label: el_collar-y }
       # - { key: el_q, id: [26],  label: el_shoulder-p }
       # - { key: el_q, id: [27],  label: el_shoulder-r }
@@ -130,6 +146,22 @@ main:
       - { key: st_tau, id: [22], label: st_wrist-y }
       - { key: st_tau, id: [23], label: st_wrist-r }
       - { key: st_tau, id: [24], label: st_wrist-p }
+      - { key: abc_tau, id: [17], label: abc_collar-y }
+      - { key: abc_tau, id: [18], label: abc_shoulder-p }
+      - { key: abc_tau, id: [19], label: abc_shoulder-r }
+      - { key: abc_tau, id: [20], label: abc_shoulder-y }
+      - { key: abc_tau, id: [21], label: abc_elbow-p }
+      - { key: abc_tau, id: [22], label: abc_wrist-y }
+      - { key: abc_tau, id: [23], label: abc_wrist-r }
+      - { key: abc_tau, id: [24], label: abc_wrist-p }
+      - { key: abst_tau, id: [17], label: abst_collar-y }
+      - { key: abst_tau, id: [18], label: abst_shoulder-p }
+      - { key: abst_tau, id: [19], label: abst_shoulder-r }
+      - { key: abst_tau, id: [20], label: abst_shoulder-y }
+      - { key: abst_tau, id: [21], label: abst_elbow-p }
+      - { key: abst_tau, id: [22], label: abst_wrist-y }
+      - { key: abst_tau, id: [23], label: abst_wrist-r }
+      - { key: abst_tau, id: [24], label: abst_wrist-p }
       - { key: torque, id: [17], label: rh_collar-y }
       - { key: torque, id: [18], label: rh_shoulder-p }
       - { key: torque, id: [19], label: rh_shoulder-r }
@@ -150,6 +182,22 @@ main:
       - { key: st_tau, id: [30], label: st_wrist-y }
       - { key: st_tau, id: [31], label: st_wrist-r }
       - { key: st_tau, id: [32], label: st_wrist-p }
+      - { key: abc_tau, id: [25], label: abc_collar-y }
+      - { key: abc_tau, id: [26], label: abc_shoulder-p }
+      - { key: abc_tau, id: [27], label: abc_shoulder-r }
+      - { key: abc_tau, id: [28], label: abc_shoulder-y }
+      - { key: abc_tau, id: [29], label: abc_elbow-p }
+      - { key: abc_tau, id: [30], label: abc_wrist-y }
+      - { key: abc_tau, id: [31], label: abc_wrist-r }
+      - { key: abc_tau, id: [32], label: abc_wrist-p }
+      - { key: abst_tau, id: [25], label: abst_collar-y }
+      - { key: abst_tau, id: [26], label: abst_shoulder-p }
+      - { key: abst_tau, id: [27], label: abst_shoulder-r }
+      - { key: abst_tau, id: [28], label: abst_shoulder-y }
+      - { key: abst_tau, id: [29], label: abst_elbow-p }
+      - { key: abst_tau, id: [30], label: abst_wrist-y }
+      - { key: abst_tau, id: [31], label: abst_wrist-r }
+      - { key: abst_tau, id: [32], label: abst_wrist-p }
       - { key: torque, id: [25], label: rh_collar-y }
       - { key: torque, id: [26], label: rh_shoulder-p }
       - { key: torque, id: [27], label: rh_shoulder-r }
@@ -170,6 +218,22 @@ main:
       - { key: rh_st_diff, id: [22],label: wrist-y }
       - { key: rh_st_diff, id: [23],label: wrist-r }
       - { key: rh_st_diff, id: [24],label: wrist-p }
+      - { key: rh_abc_diff, id: [17],label: collar-y }
+      - { key: rh_abc_diff, id: [18],label: shoulder-p }
+      - { key: rh_abc_diff, id: [19],label: shoulder-r }
+      - { key: rh_abc_diff, id: [20],label: shoulder-y }
+      - { key: rh_abc_diff, id: [21],label: elbow-p }
+      - { key: rh_abc_diff, id: [22],label: wrist-y }
+      - { key: rh_abc_diff, id: [23],label: wrist-r }
+      - { key: rh_abc_diff, id: [24],label: wrist-p }
+      - { key: rh_abst_diff, id: [17],label: collar-y }
+      - { key: rh_abst_diff, id: [18],label: shoulder-p }
+      - { key: rh_abst_diff, id: [19],label: shoulder-r }
+      - { key: rh_abst_diff, id: [20],label: shoulder-y }
+      - { key: rh_abst_diff, id: [21],label: elbow-p }
+      - { key: rh_abst_diff, id: [22],label: wrist-y }
+      - { key: rh_abst_diff, id: [23],label: wrist-r }
+      - { key: rh_abst_diff, id: [24],label: wrist-p }
       # - { key: rh_el_diff, id: [17],label: collar-y }
       # - { key: rh_el_diff, id: [18],label: shoulder-p }
       # - { key: rh_el_diff, id: [19],label: shoulder-r }
@@ -191,6 +255,22 @@ main:
       - { key: rh_st_diff, id: [30], label: wrist-y }
       - { key: rh_st_diff, id: [31], label: wrist-r }
       - { key: rh_st_diff, id: [32], label: wrist-p }
+      - { key: rh_abc_diff, id: [25],  label: collar-y }
+      - { key: rh_abc_diff, id: [26],  label: shoulder-p }
+      - { key: rh_abc_diff, id: [27],  label: shoulder-r }
+      - { key: rh_abc_diff, id: [28],  label: shoulder-y }
+      - { key: rh_abc_diff, id: [29], label: elbow-p }
+      - { key: rh_abc_diff, id: [30], label: wrist-y }
+      - { key: rh_abc_diff, id: [31], label: wrist-r }
+      - { key: rh_abc_diff, id: [32], label: wrist-p }
+      - { key: rh_abst_diff, id: [25],  label: collar-y }
+      - { key: rh_abst_diff, id: [26],  label: shoulder-p }
+      - { key: rh_abst_diff, id: [27],  label: shoulder-r }
+      - { key: rh_abst_diff, id: [28],  label: shoulder-y }
+      - { key: rh_abst_diff, id: [29], label: elbow-p }
+      - { key: rh_abst_diff, id: [30], label: wrist-y }
+      - { key: rh_abst_diff, id: [31], label: wrist-r }
+      - { key: rh_abst_diff, id: [32], label: wrist-p }
       # - { key: rh_el_diff, id: [25],  label: collar-y }
       # - { key: rh_el_diff, id: [26],  label: shoulder-p }
       # - { key: rh_el_diff, id: [27],  label: shoulder-r }

--- a/config/robot/jaxon/jaxon-joint-simulator-leg_layout.yaml
+++ b/config/robot/jaxon/jaxon-joint-simulator-leg_layout.yaml
@@ -13,6 +13,12 @@ main:
       # - { key: abc_q, id: [3],label: abc_knee-p }
       # - { key: abc_q, id: [4],label: abc_ankle-p}
       # - { key: abc_q, id: [5],label: abc_ankle-r}
+      - { key: abst_q, id: [0],label: abst_hip-y  }
+      - { key: abst_q, id: [1],label: abst_hip-r  }
+      - { key: abst_q, id: [2],label: abst_hip-p  }
+      - { key: abst_q, id: [3],label: abst_knee-p }
+      - { key: abst_q, id: [4],label: abst_ankle-p}
+      - { key: abst_q, id: [5],label: abst_ankle-r}
       # - { key: el_q, id: [0],label: el_hip-y  }
       # - { key: el_q, id: [1],label: el_hip-r  }
       # - { key: el_q, id: [2],label: el_hip-p  }
@@ -42,6 +48,12 @@ main:
       # - { key: abc_q, id: [9],  label: abc_knee-p }
       # - { key: abc_q, id: [10], label: abc_ankle-p}
       # - { key: abc_q, id: [11], label: abc_ankle-r}
+      - { key: abst_q, id: [6],  label: abst_hip-y  }
+      - { key: abst_q, id: [7],  label: abst_hip-r  }
+      - { key: abst_q, id: [8],  label: abst_hip-p  }
+      - { key: abst_q, id: [9],  label: abst_knee-p }
+      - { key: abst_q, id: [10], label: abst_ankle-p}
+      - { key: abst_q, id: [11], label: abst_ankle-r}
       # - { key: el_q, id: [6],  label: el_hip-y  }
       # - { key: el_q, id: [7],  label: el_hip-r  }
       # - { key: el_q, id: [8],  label: el_hip-p  }
@@ -105,6 +117,18 @@ main:
       - { key: st_tau, id: [3], label: st_knee-p}
       - { key: st_tau, id: [4], label: st_ankle-p}
       - { key: st_tau, id: [5], label: st_ankle-r}
+      - { key: abc_tau, id: [0], label: abc_hip-y}
+      - { key: abc_tau, id: [1], label: abc_hip-r}
+      - { key: abc_tau, id: [2], label: abc_hip-p}
+      - { key: abc_tau, id: [3], label: abc_knee-p}
+      - { key: abc_tau, id: [4], label: abc_ankle-p}
+      - { key: abc_tau, id: [5], label: abc_ankle-r}
+      - { key: abst_tau, id: [0], label: abst_hip-y}
+      - { key: abst_tau, id: [1], label: abst_hip-r}
+      - { key: abst_tau, id: [2], label: abst_hip-p}
+      - { key: abst_tau, id: [3], label: abst_knee-p}
+      - { key: abst_tau, id: [4], label: abst_ankle-p}
+      - { key: abst_tau, id: [5], label: abst_ankle-r}
       - { key: torque, id: [0], label: rh_hip-y}
       - { key: torque, id: [1], label: rh_hip-r}
       - { key: torque, id: [2], label: rh_hip-p}
@@ -121,6 +145,18 @@ main:
       - { key: st_tau, id: [9], label: st_knee-p}
       - { key: st_tau, id: [10], label: st_ankle-p}
       - { key: st_tau, id: [11], label: st_ankle-r}
+      - { key: abc_tau, id: [6], label: abc_hip-y}
+      - { key: abc_tau, id: [7], label: abc_hip-r}
+      - { key: abc_tau, id: [8], label: abc_hip-p}
+      - { key: abc_tau, id: [9], label: abc_knee-p}
+      - { key: abc_tau, id: [10], label: abc_ankle-p}
+      - { key: abc_tau, id: [11], label: abc_ankle-r}
+      - { key: abst_tau, id: [6], label: abst_hip-y}
+      - { key: abst_tau, id: [7], label: abst_hip-r}
+      - { key: abst_tau, id: [8], label: abst_hip-p}
+      - { key: abst_tau, id: [9], label: abst_knee-p}
+      - { key: abst_tau, id: [10], label: abst_ankle-p}
+      - { key: abst_tau, id: [11], label: abst_ankle-r}
       - { key: torque, id: [6], label: rh_hip-y}
       - { key: torque, id: [7], label: rh_hip-r}
       - { key: torque, id: [8], label: rh_hip-p}
@@ -137,6 +173,18 @@ main:
       - { key: rh_st_diff, id: [3],label: knee-p }
       - { key: rh_st_diff, id: [4],label: ankle-p}
       - { key: rh_st_diff, id: [5],label: ankle-r}
+      # - { key: rh_abc_diff, id: [0],label: hip-y  }
+      # - { key: rh_abc_diff, id: [1],label: hip-r  }
+      # - { key: rh_abc_diff, id: [2],label: hip-p  }
+      # - { key: rh_abc_diff, id: [3],label: knee-p }
+      # - { key: rh_abc_diff, id: [4],label: ankle-p}
+      # - { key: rh_abc_diff, id: [5],label: ankle-r}
+      - { key: rh_abst_diff, id: [0],label: hip-y  }
+      - { key: rh_abst_diff, id: [1],label: hip-r  }
+      - { key: rh_abst_diff, id: [2],label: hip-p  }
+      - { key: rh_abst_diff, id: [3],label: knee-p }
+      - { key: rh_abst_diff, id: [4],label: ankle-p}
+      - { key: rh_abst_diff, id: [5],label: ankle-r}
       # - { key: rh_el_diff, id: [0],label: hip-y  }
       # - { key: rh_el_diff, id: [1],label: hip-r  }
       # - { key: rh_el_diff, id: [2],label: hip-p  }
@@ -154,6 +202,18 @@ main:
       - { key: rh_st_diff, id: [9],  label: knee-p }
       - { key: rh_st_diff, id: [10], label: ankle-p}
       - { key: rh_st_diff, id: [11], label: ankle-r}
+      # - { key: rh_abc_diff, id: [6],  label: hip-y  }
+      # - { key: rh_abc_diff, id: [7],  label: hip-r  }
+      # - { key: rh_abc_diff, id: [8],  label: hip-p  }
+      # - { key: rh_abc_diff, id: [9],  label: knee-p }
+      # - { key: rh_abc_diff, id: [10], label: ankle-p}
+      # - { key: rh_abc_diff, id: [11], label: ankle-r}
+      - { key: rh_abst_diff, id: [6],  label: hip-y  }
+      - { key: rh_abst_diff, id: [7],  label: hip-r  }
+      - { key: rh_abst_diff, id: [8],  label: hip-p  }
+      - { key: rh_abst_diff, id: [9],  label: knee-p }
+      - { key: rh_abst_diff, id: [10], label: ankle-p}
+      - { key: rh_abst_diff, id: [11], label: ankle-r}
       # - { key: rh_el_diff, id: [6],  label: hip-y  }
       # - { key: rh_el_diff, id: [7],  label: hip-r  }
       # - { key: rh_el_diff, id: [8],  label: hip-p  }

--- a/config/robot/jaxon/jaxon-joint-simulator-torso_layout.yaml
+++ b/config/robot/jaxon/jaxon-joint-simulator-torso_layout.yaml
@@ -11,6 +11,11 @@ main:
       # - { key: abc_q, id: [14],label: abc_chest-y  }
       # - { key: abc_q, id: [15],label: abc_neck-y }
       # - { key: abc_q, id: [16],label: abc_neck-p}
+      - { key: abst_q, id: [12],label: abst_chest-r  }
+      - { key: abst_q, id: [13],label: abst_chest-p  }
+      - { key: abst_q, id: [14],label: abst_chest-y  }
+      - { key: abst_q, id: [15],label: abst_neck-y }
+      - { key: abst_q, id: [16],label: abst_neck-p }
       # - { key: el_q, id: [12],label: el_chest-r  }
       # - { key: el_q, id: [13],label: el_chest-p  }
       # - { key: el_q, id: [14],label: el_chest-y  }
@@ -46,6 +51,16 @@ main:
       - { key: st_tau, id: [14], label: st_chest-y}
       - { key: st_tau, id: [15], label: st_neck-y}
       - { key: st_tau, id: [16], label: st_neck-p}
+      - { key: abc_tau, id: [12], label: abc_chest-r}
+      - { key: abc_tau, id: [13], label: abc_chest-p}
+      - { key: abc_tau, id: [14], label: abc_chest-y}
+      - { key: abc_tau, id: [15], label: abc_neck-y}
+      - { key: abc_tau, id: [16], label: abc_neck-p}
+      - { key: abst_tau, id: [12], label: abst_chest-r}
+      - { key: abst_tau, id: [13], label: abst_chest-p}
+      - { key: abst_tau, id: [14], label: abst_chest-y}
+      - { key: abst_tau, id: [15], label: abst_neck-y}
+      - { key: abst_tau, id: [16], label: abst_neck-p}
       - { key: torque, id: [12], label: rh_chest-r}
       - { key: torque, id: [13], label: rh_chest-p}
       - { key: torque, id: [14], label: rh_chest-y}
@@ -60,6 +75,16 @@ main:
       - { key: rh_st_diff, id: [14],label: chest-y  }
       - { key: rh_st_diff, id: [15],label: neck-y }
       - { key: rh_st_diff, id: [16],label: neck-p}
+      - { key: rh_abc_diff, id: [12],label: chest-r  }
+      - { key: rh_abc_diff, id: [13],label: chest-p  }
+      - { key: rh_abc_diff, id: [14],label: chest-y  }
+      - { key: rh_abc_diff, id: [15],label: neck-y }
+      - { key: rh_abc_diff, id: [16],label: neck-p}
+      - { key: rh_abst_diff, id: [12],label: chest-r  }
+      - { key: rh_abst_diff, id: [13],label: chest-p  }
+      - { key: rh_abst_diff, id: [14],label: chest-y  }
+      - { key: rh_abst_diff, id: [15],label: neck-y }
+      - { key: rh_abst_diff, id: [16],label: neck-p}
       # - { key: rh_el_diff, id: [12],label: chest-r  }
       # - { key: rh_el_diff, id: [13],label: chest-p  }
       # - { key: rh_el_diff, id: [14],label: chest-y  }

--- a/config/robot/jaxon/jaxon_plot.yaml
+++ b/config/robot/jaxon/jaxon_plot.yaml
@@ -16,6 +16,11 @@ st_q:
   data:
     - { log: st_q, column: [0-33] }
 
+abst_q:
+  func: plot_rad2deg
+  data:
+    - { log: abst_q, column: [0-33] }
+
 el_q:
   func: plot_rad2deg
   data:
@@ -61,6 +66,18 @@ rh_st_diff:
   data:
     - { log: RobotHardware0_q, column: [0-33] }
     - { log: st_q, column: [0-33] }
+
+rh_abc_diff:
+  func: plot_rh_q_st_q
+  data:
+    - { log: RobotHardware0_q, column: [0-33] }
+    - { log: abc_q, column: [0-33] }
+
+rh_abst_diff:
+  func: plot_rh_q_st_q
+  data:
+    - { log: RobotHardware0_q, column: [0-33] }
+    - { log: abst_q, column: [0-33] }
 
 rh_el_diff:
   func: plot_rad2deg_diff
@@ -110,6 +127,14 @@ torque:
 st_tau:
   data:
     - { log: st_tau, column: [0-33] }
+
+abc_tau:
+  data:
+    - { log: abc_tau, column: [0-33] }
+
+abst_tau:
+  data:
+    - { log: abst_tau, column: [0-33] }
 
 choreonoid_torque:
   data:

--- a/config/st-main_layout.yaml
+++ b/config/st-main_layout.yaml
@@ -6,12 +6,26 @@ main:
       - { key: st_originRefZmp, id: [0-2]}
       - { key: st_originNewZmp, id: [0-2]}
       - { key: st_originActZmp, id: [0-2]}
+      - { key: abc_originActCog, id: [0-2]}
+      - { key: abc_originRefCog, id: [0-2]}
+      - { key: abc_originRefZmp, id: [0-2]}
+      - { key: abc_originNewZmp, id: [0-2]}
+      - { key: abc_originActZmp, id: [0-2]}
+      - { key: abst_originActCog, id: [0-2]}
+      - { key: abst_originRefCog, id: [0-2]}
+      - { key: abst_originRefZmp, id: [0-2]}
+      - { key: abst_originNewZmp, id: [0-2]}
+      - { key: abst_originActZmp, id: [0-2]}
     bottom_label:
 
   cog velocity:
     legends:
       - { key: st_originActCogVel, id: [0-2]}
       - { key: st_originRefCogVel, id: [0-2]}
+      - { key: abc_originActCogVel, id: [0-2]}
+      - { key: abc_originRefCogVel, id: [0-2]}
+      - { key: abst_originActCogVel, id: [0-2]}
+      - { key: abst_originRefCogVel, id: [0-2]}
     bottom_label:
 
   # root-link relative zmp:
@@ -27,9 +41,17 @@ main:
       - { key: sh_baseRpyOut, id: [0-2] }
       - { key: st_currentBaseRpy, id: [0-2] }
       - { key: st_actBaseRpy, id: [0-2] }
+      - { key: abc_currentBaseRpy, id: [0-2] }
+      - { key: abc_actBaseRpy, id: [0-2] }
+      - { key: abst_currentBaseRpy, id: [0-2] }
+      - { key: abst_actBaseRpy, id: [0-2] }
 
   base rpy vel:
     legends:
       - { key: sh_baseRpyVel, id: [0-2] }
       - { key: st_currentBaseRpyVel, id: [0-2] }
       - { key: st_actBaseRpyVel, id: [0-2] }
+      - { key: abc_currentBaseRpyVel, id: [0-2] }
+      - { key: abc_actBaseRpyVel, id: [0-2] }
+      - { key: abst_currentBaseRpyVel, id: [0-2] }
+      - { key: abst_actBaseRpyVel, id: [0-2] }

--- a/config/wrench-arm_layout.yaml
+++ b/config/wrench-arm_layout.yaml
@@ -5,6 +5,10 @@ main:
       - { key: sh_lhsensorOut, id: [0-2] }
       - { key: st_ref_rhsensor, id: [0-2] }
       - { key: st_ref_lhsensor, id: [0-2] }
+      - { key: abc_ref_rhsensor, id: [0-2] }
+      - { key: abc_ref_lhsensor, id: [0-2] }
+      - { key: abst_ref_rhsensor, id: [0-2] }
+      - { key: abst_ref_lhsensor, id: [0-2] }
       - { key: rmfo_off_rhsensor, id: [0-2] }
       - { key: rmfo_off_lhsensor, id: [0-2] }
     bottom_label:
@@ -16,6 +20,10 @@ main:
       - { key: abc_contactStates, id: [3], label: larm }
       - { key: st_debugData, id: [2], label: rarm_contact_phase }
       - { key: st_debugData, id: [3], label: larm_contact_phase }
+      - { key: abc_debugData, id: [2], label: rarm_contact_phase }
+      - { key: abc_debugData, id: [3], label: larm_contact_phase }
+      - { key: abst_debugData, id: [2], label: rarm_contact_phase }
+      - { key: abst_debugData, id: [3], label: larm_contact_phase }
       - { key: abc_controlSwingSupportTime, id: [2], label: rarm_time }
       - { key: abc_controlSwingSupportTime, id: [3], label: larm_time }
     bottom_label:
@@ -26,6 +34,10 @@ main:
       - { key: sh_lhsensorOut, id: [3-5] }
       - { key: st_ref_rhsensor, id: [3-5] }
       - { key: st_ref_lhsensor, id: [3-5] }
+      - { key: abc_ref_rhsensor, id: [3-5] }
+      - { key: abc_ref_lhsensor, id: [3-5] }
+      - { key: abst_ref_rhsensor, id: [3-5] }
+      - { key: abst_ref_lhsensor, id: [3-5] }
       - { key: rmfo_off_rhsensor, id: [3-5] }
       - { key: rmfo_off_lhsensor, id: [3-5] }
     bottom_label:

--- a/config/wrench-leg_layout.yaml
+++ b/config/wrench-leg_layout.yaml
@@ -6,6 +6,10 @@ main:
       - { key: sh_lfsensorOut, id: [2] }
       - { key: st_ref_rfsensor, id: [2] }
       - { key: st_ref_lfsensor, id: [2] }
+      - { key: abc_ref_rfsensor, id: [2] }
+      - { key: abc_ref_lfsensor, id: [2] }
+      - { key: abst_ref_rfsensor, id: [2] }
+      - { key: abst_ref_lfsensor, id: [2] }
       - { key: rmfo_off_rfsensor, id: [2] }
       - { key: rmfo_off_lfsensor, id: [2] }
     bottom_label:
@@ -17,6 +21,10 @@ main:
       - { key: sh_lfsensorOut, id: [3-4] }
       - { key: st_ref_rfsensor, id: [3-4] }
       - { key: st_ref_lfsensor, id: [3-4] }
+      - { key: abc_ref_rfsensor, id: [3-4] }
+      - { key: abc_ref_lfsensor, id: [3-4] }
+      - { key: abst_ref_rfsensor, id: [3-4] }
+      - { key: abst_ref_lfsensor, id: [3-4] }
       - { key: rmfo_off_rfsensor, id: [3-4] }
       - { key: rmfo_off_lfsensor, id: [3-4] }
     bottom_label:
@@ -28,6 +36,10 @@ main:
       - { key: abc_contactStates, id: [1], label: lleg }
       - { key: st_debugData, id: [0], label: rleg_contact_phase }
       - { key: st_debugData, id: [1], label: lleg_contact_phase }
+      - { key: abc_debugData, id: [0], label: rleg_contact_phase }
+      - { key: abc_debugData, id: [1], label: lleg_contact_phase }
+      - { key: abst_debugData, id: [0], label: rleg_contact_phase }
+      - { key: abst_debugData, id: [1], label: lleg_contact_phase }
       - { key: abc_controlSwingSupportTime, id: [0], label: rleg_time }
       - { key: abc_controlSwingSupportTime, id: [1], label: lleg_time }
     bottom_label:
@@ -39,6 +51,10 @@ main:
       - { key: sh_lfsensorOut, id: [0-1] }
       - { key: st_ref_rfsensor, id: [0-1] }
       - { key: st_ref_lfsensor, id: [0-1] }
+      - { key: abc_ref_rfsensor, id: [0-1] }
+      - { key: abc_ref_lfsensor, id: [0-1] }
+      - { key: abst_ref_rfsensor, id: [0-1] }
+      - { key: abst_ref_lfsensor, id: [0-1] }
       - { key: rmfo_off_rfsensor, id: [0-1] }
       - { key: rmfo_off_lfsensor, id: [0-1] }
     bottom_label:
@@ -50,6 +66,10 @@ main:
       - { key: sh_lfsensorOut, id: [5] }
       - { key: st_ref_rfsensor, id: [5] }
       - { key: st_ref_lfsensor, id: [5] }
+      - { key: abc_ref_rfsensor, id: [5] }
+      - { key: abc_ref_lfsensor, id: [5] }
+      - { key: abst_ref_rfsensor, id: [5] }
+      - { key: abst_ref_lfsensor, id: [5] }
       - { key: rmfo_off_rfsensor, id: [5] }
       - { key: rmfo_off_lfsensor, id: [5] }
     bottom_label:

--- a/src/log_plotter/log_parser.py
+++ b/src/log_plotter/log_parser.py
@@ -62,10 +62,9 @@ class LogParser(object):
         for topic, data in zip(topic_list, data_list):
             self.dataListDict[topic] = data
         # set the fastest time as 0
-        min_time = min([self.dataListDict[topic][0][0] for topic in topic_list])
-        for topic in topic_list:
-            raw_time = self.dataListDict[topic][:, 0]
-            self.dataListDict[topic][:, 0] = [x - min_time for x in raw_time]
+        min_time = min([data[0][0] for data in self.dataListDict.values() if data is not None])
+        for log_name, data in self.dataListDict.items():
+            if data is not None: self.dataListDict[log_name][:, 0] = data[:, 0] - min_time
         # convert servoState from int to float
         if 'RobotHardware0_servoState' in topic_list:
             ss_tmp = self.dataListDict['RobotHardware0_servoState'][:, 1:]

--- a/src/log_plotter/plot_utils.py
+++ b/src/log_plotter/plot_utils.py
@@ -33,7 +33,9 @@ def readOneTopic(fname):
                 data.append([float(x) for x in dl])
     except Exception as e:
         print('[readOneTopic] error occured while reading {}'.format(fname))
-        raise e
+        print('[readOneTopic] {} may not exist.'.format(os.path.basename(fname)))
+        print('[readOneTopic] skip data and return None data')
+        return None
     return numpy.array(data)
 
 def findFile(pattern, path):


### PR DESCRIPTION
@YutaKojio @98shimpei
log_plotterのユーザが増えてきたのでhotfix的な修正ですが，abc (with st)とabstに対応したつもりです
_plot.yamlと_layout.yamlにabcとabstの分を記述しておいて，
ログの読み込みやプロット時にファイルが存在しなかったら，try exceptで例外処理でスキップするようになっています

とりあえず，それっぽいデータにはabcとabstの設定を追加してみました

abc with stでst_qがabc_qで元々あるポートと重複するのはよく分からなかったので設定を書いていません
