### PR TITLE
enable labeling

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ main:
 Falseにすることで前にグラフと同じ行に表示することができる
 * `title: bool`  
 Falseにすることでグラフ上部のタイトルを非表示にする
-* `bottom_label: 'string' (default: "time [s]")`  
+* `bottom_label: 'string' (default: False)`  
 横軸ラベルを設定
 * `left_label: 'string' (default: False)`  
 縦軸ラベルを設定

--- a/src/log_plotter/datalogger_plotter_with_pyqtgraph.py
+++ b/src/log_plotter/datalogger_plotter_with_pyqtgraph.py
@@ -147,6 +147,12 @@ class LogPlotter(object):
             col_num = len(self.view.ci.rows[i])
             for j in range(col_num):
                 cur_item = self.view.ci.rows[i][j]
+                # we need this to suppress si-prefix until https://github.com/pyqtgraph/pyqtgraph/pull/293 is merged
+                for ax in cur_item.axes.values():
+                    ax['item'].enableAutoSIPrefix(enable=False)
+                    ax['item'].autoSIPrefixScale = 1.0
+                    ax['item'].labelUnitPrefix = ''
+                    ax['item'].setLabel()
                 # set left label
                 title = cur_item.titleLabel.text
                 tmp_left_label = None
@@ -164,12 +170,6 @@ class LogPlotter(object):
                 # cur_item.setLabel("left", text="", units=tmp_left_label)
                 if tmp_left_label:
                     cur_item.setLabel("left", text=tmp_left_label)
-                # we need this to suppress si-prefix until https://github.com/pyqtgraph/pyqtgraph/pull/293 is merged
-                for ax in cur_item.axes.values():
-                    ax['item'].enableAutoSIPrefix(enable=False)
-                    ax['item'].autoSIPrefixScale = 1.0
-                    ax['item'].labelUnitPrefix = ''
-                    ax['item'].setLabel()
                 # set bottom label
                 cur_item.setLabel("bottom", text=self.legend_list[i][j][0].group_info['bottom_label'])
 
@@ -385,10 +385,10 @@ class LogPlotter(object):
         self.getData()
         self.setLayout()
         self.plotData()
+        self.setFont()
         self.setLabel()
         self.setItemSize()
         self.linkAxes()
-        self.setFont()
         self.customMenu()
         self.customMenu2()
         self.view.showMaximized()


### PR DESCRIPTION
グラフをプロットしていて，x軸,y軸ともに表示されないようになっていました．
ちゃんとデバッグしていないのでdraftにしていますが，以下の点を修正しました．

- "suppress si-prefix..." の中で`ax.setLabel()`引数なしを実行してしまっているので，その直前の`left_label`が無効化されていた．そのため順序を入れ替えた
  - そもそもこれをコメントアウトしてもx軸，y軸ともに表示されたので，もう必要なくなっている可能性もあります．
- `self.setFont()`のあとに`self.setLabel()`しないと表示されない
  - `self.setFont()`の中で`ax.setLabel(**font_style)`でデフォルトのtext=Noneが入っていると思います．
- `bottom_label`がデフォルトで"time [s]"にはなっていないので，REAMEを修正